### PR TITLE
Make UNITS configurable

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -1,17 +1,6 @@
 // HumanizeDuration.js - http://git.io/j0HgmQ
 
 (function(global) {
-  var UNITS = {
-    y: 31557600000,
-    mo: 2629800000,
-    w: 604800000,
-    d: 86400000,
-    h: 3600000,
-    m: 60000,
-    s: 1000,
-    ms: 1
-  };
-
   var languages = {
     ar: {
       y: function(c) { return ((c === 1) ? "سنة" : "سنوات"); },
@@ -271,7 +260,17 @@
       spacer: " ",
       units: ["y", "mo", "w", "d", "h", "m", "s"],
       languages: {},
-      round: false
+      round: false,
+      unitMeasures: {
+        y: 31557600000,
+        mo: 2629800000,
+        w: 604800000,
+        d: 86400000,
+        h: 3600000,
+        m: 60000,
+        s: 1000,
+        ms: 1
+      }
     }, passedOptions);
   }
 
@@ -300,7 +299,7 @@
     for (var i = 0, len = options.units.length; i < len; i++) {
 
       unitName = options.units[i];
-      unitMS = UNITS[unitName];
+      unitMS = options.unitMeasures[unitName];
 
       // What's the number of full units we can fit?
       if ((i + 1) === len) {

--- a/test/humanizer.coffee
+++ b/test/humanizer.coffee
@@ -31,6 +31,22 @@ describe "humanizer", ->
     assert.equal h(ms("6h")), "0.25 days"
     assert.equal h(ms("7d")), "7 days"
 
+  it "can overwrite the unit measures in the initializer", ->
+    h = humanizer
+      unitMeasures:
+        y: 10512000000,
+        mo: 864000000,
+        w: 144000000,
+        d: 28800000
+        h: 3600000
+        m: 60000
+        s: 1000
+        ms: 1
+    assert.equal h(1000), "1 second"
+    assert.equal h(3600000), "1 hour"
+    assert.equal h(28800000), "1 day"
+    assert.equal h(144000000), "1 week"
+
   it "can change the decimal", ->
     h = humanizer(units: ["s"], decimal: 'what')
     assert.equal h(1234), '1what234 seconds'


### PR DESCRIPTION
If you want to humanize durations for worktime measures, where e.g. 1 day has only 8 hours, you have to be able to modify UNITS. Therefore it would be great to extend these unit measures via options.

In this example I only duration till "weeks" but each week has 40h and each day has 8h, therefore:

```javascript
var myHumanizer = humanizeDuration.humanizer({
	units: ['w', 'd', 'h', 'm', 's'],
	unitMeasures: {
		w: 144000000,
		d: 28800000,
		h: 3600000,
		m: 60000,
		s: 1000,
		ms: 1
	}
});
```