### PR TITLE
Fix round with largest

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -359,6 +359,14 @@
       ms -= unitCount * unitMS
     }
 
+    var firstOccupiedUnitIndex = 0
+    for (i = 0; i < pieces.length; i++) {
+      if (pieces[i].unitCount) {
+        firstOccupiedUnitIndex = i
+        break
+      }
+    }
+
     if (options.round) {
       var ratioToLargerUnit, previousPiece
       for (i = pieces.length - 1; i >= 0; i--) {
@@ -370,7 +378,7 @@
         previousPiece = pieces[i - 1]
 
         ratioToLargerUnit = options.unitMeasures[previousPiece.unitName] / options.unitMeasures[piece.unitName]
-        if ((piece.unitCount % ratioToLargerUnit) === 0 || (options.largest && ((options.largest - 1) < i))) {
+        if ((piece.unitCount % ratioToLargerUnit) === 0 || (options.largest && ((options.largest - 1) < (i - firstOccupiedUnitIndex)))) {
           previousPiece.unitCount += piece.unitCount / ratioToLargerUnit
           piece.unitCount = 0
         }

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -101,6 +101,7 @@ describe('humanizer', function () {
     assert.equal(h(3692131200000, { largest: 1 }), '117 years')
     assert.equal(h(3692131200000, { largest: 2 }), '117 years')
     assert.equal(h(3692131200001, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
+    assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
   })
 
   it('can ask for the largest units', function () {


### PR DESCRIPTION
I saw #98 and figured it'd be a good excuse to dig around and see how this project actually works.

As @astoellis [pointed out](https://github.com/EvanHahn/HumanizeDuration.js/issues/98#issuecomment-212009835), the problem occurred when you use both the `round` and `largest` options at once. That [block of code](https://github.com/EvanHahn/HumanizeDuration.js/blob/230479454d55ce972ef54d9229716e198b829af2/humanize-duration.js#L381-L384) he mentions only gets hit when both options are active.

Slightly farther down, the `largest` option is [handled properly](https://github.com/EvanHahn/HumanizeDuration.js/blob/230479454d55ce972ef54d9229716e198b829af2/humanize-duration.js#L395), by waiting for `largest` number of pieces that actually _have a value_ before `break`ing out of there.

However, the problematic section of code only relates the `largest` value to the current `i`, with no regards to which pieces are actually occupied by a non-zero `unitCount`. In effect, this means that `round` assumes that a `largest: 3` option refers to units years/months/weeks. If the initial `ms` you're calculating is less than a week, you're left with all zeros, resulting in the `0 seconds` output.

By calculating `firstOccupiedUnitIndex` up front, we can properly compare the current index to `largest` when rounding.