### PR TITLE
Fix Bug with mode {round = true}

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -359,14 +359,6 @@
       ms -= unitCount * unitMS
     }
 
-    var firstOccupiedUnitIndex = 0
-    for (i = 0; i < pieces.length; i++) {
-      if (pieces[i].unitCount) {
-        firstOccupiedUnitIndex = i
-        break
-      }
-    }
-
     if (options.round) {
       for (i = pieces.length - 1; i >= 0; i--) {
         pieces[i].unitCount = Math.round(pieces[i].unitCount)

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -360,9 +360,37 @@
     }
 
     if (options.round) {
+      var next
+      var lastNotEmpty//Save here last index of pieces that is not empty
       for (i = pieces.length - 1; i >= 0; i--) {
         pieces[i].unitCount = Math.round(pieces[i].unitCount)
+
+        next = pieces[i-1]
+        if(next && pieces[i].unitCount * options.unitMeasures[pieces[i].unitName] === options.unitMeasures[next.unitName]) {
+              next.unitCount++
+              pieces[i].unitCount = 0
+        }
+
+        if (pieces[i].unitCount !== 0) {
+          lastNotEmpty = i
+        }
       }
+
+      //Need extra rounding to display only largest units
+      if (options.largest && (pieces.length - 1 - lastNotEmpty) > 1 ) {
+        for (i = pieces.length - 1; i >= 0; i--) {
+          pieces[i].unitCount = Math.round(pieces[i].unitCount)
+
+          next = pieces[i-1]
+          if(next && (options.largest <= i) && (i >= lastNotEmpty)) {
+            var ratioToLargerUnit = options.unitMeasures[next.unitName] / options.unitMeasures[pieces[i].unitName]
+            next.unitCount += pieces[i].unitCount / ratioToLargerUnit
+            pieces[i].unitCount = 0
+          }
+
+        }
+      }
+
     }
 
     var result = []

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -361,14 +361,14 @@
 
     if (options.round) {
       var next
-      var lastNotEmpty//Save here last index of pieces that is not empty
+      var lastNotEmpty // Save here last index of pieces that is not empty.
       for (i = pieces.length - 1; i >= 0; i--) {
         pieces[i].unitCount = Math.round(pieces[i].unitCount)
 
-        next = pieces[i-1]
-        if(next && pieces[i].unitCount * options.unitMeasures[pieces[i].unitName] === options.unitMeasures[next.unitName]) {
-              next.unitCount++
-              pieces[i].unitCount = 0
+        next = pieces[i - 1]
+        if (next && pieces[i].unitCount * options.unitMeasures[pieces[i].unitName] === options.unitMeasures[next.unitName]) {
+          next.unitCount++
+          pieces[i].unitCount = 0
         }
 
         if (pieces[i].unitCount !== 0) {
@@ -376,21 +376,19 @@
         }
       }
 
-      //Need extra rounding to display only largest units
-      if (options.largest && (pieces.length - 1 - lastNotEmpty) > 1 ) {
+      // Need extra rounding to display only largest units
+      if (options.largest && (pieces.length - 1 - lastNotEmpty) > 1) {
         for (i = pieces.length - 1; i >= 0; i--) {
           pieces[i].unitCount = Math.round(pieces[i].unitCount)
 
-          next = pieces[i-1]
-          if(next && (options.largest <= i) && (i >= lastNotEmpty)) {
+          next = pieces[i - 1]
+          if (next && (options.largest <= i) && (i >= lastNotEmpty)) {
             var ratioToLargerUnit = options.unitMeasures[next.unitName] / options.unitMeasures[pieces[i].unitName]
             next.unitCount += pieces[i].unitCount / ratioToLargerUnit
             pieces[i].unitCount = 0
           }
-
         }
       }
-
     }
 
     var result = []

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -386,6 +386,9 @@
             var ratioToLargerUnit = options.unitMeasures[next.unitName] / options.unitMeasures[pieces[i].unitName]
             next.unitCount += pieces[i].unitCount / ratioToLargerUnit
             pieces[i].unitCount = 0
+          } else if (next && pieces[i].unitCount * options.unitMeasures[pieces[i].unitName] === options.unitMeasures[next.unitName]) {
+            next.unitCount++
+            pieces[i].unitCount = 0
           }
         }
       }

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -368,20 +368,8 @@
     }
 
     if (options.round) {
-      var ratioToLargerUnit, previousPiece
       for (i = pieces.length - 1; i >= 0; i--) {
-        piece = pieces[i]
-        piece.unitCount = Math.round(piece.unitCount)
-
-        if (i === 0) { break }
-
-        previousPiece = pieces[i - 1]
-
-        ratioToLargerUnit = options.unitMeasures[previousPiece.unitName] / options.unitMeasures[piece.unitName]
-        if ((piece.unitCount % ratioToLargerUnit) === 0 || (options.largest && ((options.largest - 1) < (i - firstOccupiedUnitIndex)))) {
-          previousPiece.unitCount += piece.unitCount / ratioToLargerUnit
-          piece.unitCount = 0
-        }
+        pieces[i].unitCount = Math.round(pieces[i].unitCount)
       }
     }
 

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -99,7 +99,7 @@ describe('humanizer', function () {
     var h = humanizer({ round: true })
 
     assert.equal(h(3692131200000, { largest: 1 }), '117 years')
-    assert.equal(h(3692131200000, { largest: 2 }), '117 years')
+    assert.equal(h(3692131200000, { largest: 2 }), '116 years, 12 months')
     assert.equal(h(3692131200001, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
     assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
   })

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -99,7 +99,7 @@ describe('humanizer', function () {
     var h = humanizer({ round: true })
 
     assert.equal(h(3692131200000, { largest: 1 }), '117 years')
-    assert.equal(h(3692131200000, { largest: 2 }), '116 years, 12 months')
+    assert.equal(h(3692131200000, { largest: 2 }), '117 years')
     assert.equal(h(3692131200001, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
     assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
   })


### PR DESCRIPTION
In case like this:

```
let time = humanizeDuration(5219998, {
            delimiter: ' and ',
            units: ['d', 'h', 'm'],
            round = true,
            largest: 2
});
console.log(time);
```

The old algorithm give a wrong result: "**1 hour**".
With my fix : "**1 hour and 27 minutes**"