### PR TITLE
Conjunctions

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -303,6 +303,7 @@
       delimiter: ', ',
       spacer: ' ',
       conjunction: '',
+      serialComma: true,
       units: ['y', 'mo', 'w', 'd', 'h', 'm', 's'],
       languages: {},
       round: false,
@@ -402,7 +403,7 @@
       } else if (result.length === 2) {
         return result.join(options.conjunction)
       } else if (result.length > 2) {
-        return result.slice(0, -1).join(options.delimiter) + options.conjunction + result.slice(-1)
+        return result.slice(0, -1).join(options.delimiter) + (options.serialComma ? ',' : '') + options.conjunction + result.slice(-1)
       }
     } else {
       return render(0, options.units[options.units.length - 1], dictionary, options)

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -302,6 +302,7 @@
       language: 'en',
       delimiter: ', ',
       spacer: ' ',
+      conjunction: '',
       units: ['y', 'mo', 'w', 'd', 'h', 'm', 's'],
       languages: {},
       round: false,
@@ -396,7 +397,13 @@
     }
 
     if (result.length) {
-      return result.join(options.delimiter)
+      if (!options.conjunction || result.length === 1) {
+        return result.join(options.delimiter)
+      } else if (result.length === 2) {
+          return result.join(options.conjunction)
+      } else if (result.length > 2) {
+        return result.slice(0, -1).join(options.delimiter) + options.conjunction + result.slice(-1);
+      }
     } else {
       return render(0, options.units[options.units.length - 1], dictionary, options)
     }

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -400,9 +400,9 @@
       if (!options.conjunction || result.length === 1) {
         return result.join(options.delimiter)
       } else if (result.length === 2) {
-          return result.join(options.conjunction)
+        return result.join(options.conjunction)
       } else if (result.length > 2) {
-        return result.slice(0, -1).join(options.delimiter) + options.conjunction + result.slice(-1);
+        return result.slice(0, -1).join(options.delimiter) + options.conjunction + result.slice(-1)
       }
     } else {
       return render(0, options.units[options.units.length - 1], dictionary, options)

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -38,7 +38,18 @@ describe('humanizer', function () {
     assert.equal(h(0), '0 seconds')
     assert.equal(h(1000), '1 second')
     assert.equal(h(260040000), '3 days and 14 minutes')
-    assert.equal(h(10874000), '3 hours, 1 minute and 14 seconds')
+    assert.equal(h(10874000), '3 hours, 1 minute, and 14 seconds')
+  })
+
+  it('can use a conjunction without a serial comma', function () {
+    var h = humanizer({
+      conjunction: ' & ',
+      serialComma: false
+    })
+
+    assert.equal(h(1000), '1 second')
+    assert.equal(h(260040000), '3 days & 14 minutes')
+    assert.equal(h(10874000), '3 hours, 1 minute & 14 seconds')
   })
 
   it('can change the units', function () {

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -32,6 +32,15 @@ describe('humanizer', function () {
     assert.equal(h(260040000), '3 whole days, 14 whole minutes')
   })
 
+  it('can use a conjunction', function () {
+    var h = humanizer({ conjunction: ' and ' })
+
+    assert.equal(h(0), '0 seconds')
+    assert.equal(h(1000), '1 second')
+    assert.equal(h(260040000), '3 days and 14 minutes')
+    assert.equal(h(10874000), '3 hours, 1 minute and 14 seconds')
+  })
+
   it('can change the units', function () {
     var h = humanizer({ units: ['d'] })
 


### PR DESCRIPTION
This adds an option for using a conjunction rather than the final delimiter. For example, the output could be `3 days and 14 minutes` or `3 hours, 1 minute & 14 seconds`.