### PR TITLE
Added support for custom rounding functions.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+Unreleased
+==================
+
+* new: custom rounding function support
+
 3.9.1 / 2016-07-24
 ==================
 

--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ humanizeDuration(3600000, { units: ['d', 'h'] })  // '1 hour'
 
 **round**
 
-Boolean value. Use `true` to [round](https://en.wikipedia.org/wiki/Rounding#Round_half_up) the smallest unit displayed (can be combined with `largest` and `units`).
+Boolean value or function. Use `true` to [round](https://en.wikipedia.org/wiki/Rounding#Round_half_up) the smallest unit displayed (can be combined with `largest` and `units`), or pass a function to customize how rounding is done.
 
 ```js
 humanizeDuration(1200)                   // '1.2 seconds'
 humanizeDuration(1200, { round: true })  // '1 second'
 humanizeDuration(1600, { round: true })  // '2 seconds'
+humanizeDuration(1600, { round: Math.floor })  // '1 second'
 ```
 
 **decimal**
@@ -260,6 +261,7 @@ Lovingly made by [Evan Hahn](http://evanhahn.com/) with help from:
 * [Manh Tuan](https://github.com/J2TeaM) for Vietnamese support
 * [Leonard Lee](https://github.com/sheeeng) for Indonesian & Malay support
 * [Jesse Jackson](https://github.com/jsejcksn) for documentation help
+* [David H. Bronke](https://github.com/whitelynx) for custom rounding function support
 
 Licensed under the permissive [Unlicense](http://unlicense.org/). Enjoy!
 

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "Vidmantas Drasutis (https://github.com/drasius2)",
     "Manh Tuan (https://github.com/J2TeaM)",
     "Leonard Lee (https://github.com/sheeeng)",
-    "Jesse Jackson (https://github.com/jsejcksn)"
+    "Jesse Jackson (https://github.com/jsejcksn)",
+    "David H. Bronke (https://github.com/whitelynx)"
   ],
   "version": "3.9.1",
   "description": "Convert millisecond durations to English and many other languages.",

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -392,10 +392,11 @@
     }
 
     if (options.round) {
+      var roundFunction = (typeof options.round === 'function') ? options.round : Math.round
       var ratioToLargerUnit, previousPiece
       for (i = pieces.length - 1; i >= 0; i--) {
         piece = pieces[i]
-        piece.unitCount = Math.round(piece.unitCount)
+        piece.unitCount = roundFunction(piece.unitCount)
 
         if (i === 0) { break }
 

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -361,7 +361,7 @@
     var pieces = []
 
     // Start at the top and keep removing units, bit by bit.
-    var unitName, unitMS, unitCount
+    var unitName, unitMS, unitCount, firstOccupiedUnitIndex
     for (i = 0, len = options.units.length; i < len; i++) {
       unitName = options.units[i]
       unitMS = options.unitMeasures[unitName]
@@ -373,6 +373,10 @@
         unitCount = Math.floor(ms / unitMS)
       }
 
+      if (unitCount && firstOccupiedUnitIndex === undefined) {
+        firstOccupiedUnitIndex = i
+      }
+
       // Add the string.
       pieces.push({
         unitCount: unitCount,
@@ -381,14 +385,6 @@
 
       // Remove what we just figured out.
       ms -= unitCount * unitMS
-    }
-
-    var firstOccupiedUnitIndex = 0
-    for (i = 0; i < pieces.length; i++) {
-      if (pieces[i].unitCount) {
-        firstOccupiedUnitIndex = i
-        break
-      }
     }
 
     if (options.round) {

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -362,19 +362,23 @@
 
     // Start at the top and keep removing units, bit by bit.
     var unitName, unitMS, unitCount, firstOccupiedUnitIndex
-    for (i = 0, len = options.units.length; i < len; i++) {
+    var lastShownUnitIndex = options.units.length - 1
+    for (i = 0; i <= lastShownUnitIndex; i++) {
       unitName = options.units[i]
       unitMS = options.unitMeasures[unitName]
 
-      // What's the number of full units we can fit?
-      if (i + 1 === len) {
-        unitCount = ms / unitMS
-      } else {
-        unitCount = Math.floor(ms / unitMS)
+      unitCount = ms / unitMS
+
+      if (Math.floor(unitCount) && firstOccupiedUnitIndex === undefined) {
+        firstOccupiedUnitIndex = i
+        if (options.largest) {
+          lastShownUnitIndex = Math.min(lastShownUnitIndex, firstOccupiedUnitIndex + options.largest - 1)
+        }
       }
 
-      if (unitCount && firstOccupiedUnitIndex === undefined) {
-        firstOccupiedUnitIndex = i
+      // What's the number of full units we can fit?
+      if (i !== lastShownUnitIndex) {
+        unitCount = Math.floor(unitCount)
       }
 
       // Add the string.
@@ -399,21 +403,19 @@
         previousPiece = pieces[i - 1]
 
         ratioToLargerUnit = options.unitMeasures[previousPiece.unitName] / options.unitMeasures[piece.unitName]
-        if ((piece.unitCount % ratioToLargerUnit) === 0 || (options.largest && ((options.largest - 1) < (i - firstOccupiedUnitIndex)))) {
-          previousPiece.unitCount += piece.unitCount / ratioToLargerUnit
-          piece.unitCount = 0
+        if (piece.unitCount >= ratioToLargerUnit) {
+          previousPiece.unitCount += Math.floor(piece.unitCount / ratioToLargerUnit)
+          piece.unitCount = piece.unitCount % ratioToLargerUnit
         }
       }
     }
 
     var result = []
-    for (i = 0, pieces.length; i < len; i++) {
+    for (i = 0, len = pieces.length; i < len; i++) {
       piece = pieces[i]
       if (piece.unitCount) {
         result.push(render(piece.unitCount, piece.unitName, dictionary, options))
       }
-
-      if (result.length === options.largest) { break }
     }
 
     if (result.length) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "Vidmantas Drasutis (https://github.com/drasius2)",
     "Manh Tuan (https://github.com/J2TeaM)",
     "Leonard Lee (https://github.com/sheeeng)",
-    "Jesse Jackson (https://github.com/jsejcksn)"
+    "Jesse Jackson (https://github.com/jsejcksn)",
+    "David H. Bronke (https://github.com/whitelynx)"
   ],
   "version": "3.9.1",
   "description": "Convert millisecond durations to English and many other languages.",
@@ -56,6 +57,7 @@
       "define",
       "describe",
       "it",
+      "xit",
       "before"
     ]
   }

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -124,6 +124,49 @@ describe('humanizer', function () {
     assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
   })
 
+  it('can round using a custom function', function () {
+    var h = humanizer({ round: Math.ceil })
+
+    assert.equal(h(0), '0 seconds')
+    assert.equal(h(1), '1 second')
+    assert.equal(h(499), '1 second')
+    assert.equal(h(500), '1 second')
+    assert.equal(h(999), '1 second')
+    assert.equal(h(1000), '1 second')
+    assert.equal(h(1001), '2 seconds')
+    assert.equal(h(2000), '2 seconds')
+    assert.equal(h(120001), '2 minutes, 1 second')
+    assert.equal(h(121499), '2 minutes, 2 seconds')
+    assert.equal(h(122000), '2 minutes, 2 seconds')
+  })
+
+  it('can round using a custom function with the "units" option', function () {
+    var h = humanizer({ round: Math.ceil })
+
+    assert.equal(h(82800000, { units: ['y', 'mo', 'w', 'd', 'h'] }), '23 hours')
+    assert.equal(h(82800001, { units: ['y', 'mo', 'w', 'd', 'h'] }), '1 day')
+    assert.equal(h(604800000, { units: ['y', 'mo', 'w', 'd', 'h'] }), '1 week')
+    assert.equal(h(604800001, { units: ['y', 'mo', 'w', 'd', 'h'] }), '1 week, 1 hour')
+    assert.equal(h(3660681600000, { units: ['y', 'mo'] }), '116 years')
+    assert.equal(h(3660681600001, { units: ['y', 'mo'] }), '116 years, 1 month')
+    assert.equal(h(3692028600000, { units: ['y', 'mo', 'w', 'd', 'h', 'm'] }), '116 years, 11 months, 4 weeks')
+    assert.equal(h(3692028600001, { units: ['y', 'mo', 'w', 'd', 'h', 'm'] }), '116 years, 11 months, 4 weeks, 1 minute')
+    assert.equal(h(3692239199999, { units: ['y', 'mo', 'w', 'd', 'h', 'm'] }), '116 years, 11 months, 4 weeks, 2 days, 10 hours, 30 minutes')
+    assert.equal(h(3692239200000, { units: ['y', 'mo', 'w', 'd', 'h', 'm'] }), '117 years')
+  })
+
+  it('can round using a custom function with the "largest" option', function () {
+    var h = humanizer({ round: Math.ceil })
+
+    assert.equal(h(3692239200001, { largest: 1 }), '118 years')
+    assert.equal(h(3692239200001, { largest: 2 }), '117 years, 1 month')
+    assert.equal(h(3692131199999, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
+    assert.equal(h(3692131200001, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes, 1 second')
+    assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
+    assert.equal(h(3692239199999, { largest: 1 }), '117 years') // FIXME: Returns '118 years' for some reason?
+    assert.equal(h(3692239199999, { largest: 2 }), '117 years') // FIXME: Returns '116 years, 13 months' for some reason?
+  })
+
   it('can ask for the largest units', function () {
     var h = humanizer({ largest: 2 })
 

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -122,6 +122,9 @@ describe('humanizer', function () {
     assert.equal(h(3692131200000, { largest: 2 }), '117 years')
     assert.equal(h(3692131200001, { largest: 100 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
     assert.equal(h(2838550, { largest: 3 }), '47 minutes, 19 seconds')
+    assert.equal(h(540360012, { largest: 2 }), '6 days, 6 hours')
+    assert.equal(h(540360012, { largest: 3 }), '6 days, 6 hours, 6 minutes')
+    assert.equal(h(540360012, { largest: 100 }), '6 days, 6 hours, 6 minutes')
   })
 
   it('can round using a custom function', function () {
@@ -173,9 +176,8 @@ describe('humanizer', function () {
     assert.equal(h(0), '0 seconds')
     assert.equal(h(1000), '1 second')
     assert.equal(h(2000), '2 seconds')
-    assert.equal(h(540360012), '6 days, 6 hours')
-    assert.equal(h(540360012), '6 days, 6 hours')
-    assert.equal(h(540360012, { largest: 3 }), '6 days, 6 hours, 6 minutes')
+    assert.equal(h(540360012), '6 days, 6.100003333333333 hours')
+    assert.equal(h(540360012, { largest: 3 }), '6 days, 6 hours, 6.0002 minutes')
     assert.equal(h(540360012, { largest: 100 }), '6 days, 6 hours, 6 minutes, 0.012 seconds')
   })
 


### PR DESCRIPTION
Two test cases in the unit test for usage with the `largest` option currently fail in ways that suggest issues in other code.

----

Some background on my motivations for this change: Since version 2.0.0, Moment.js has a [different default rounding scheme](http://momentjs.com/docs/#/displaying/difference/) than HumanizeDuration.js. (though [that is configurable](http://momentjs.com/docs/#/customization/relative-time-rounding/)) In many cases Moment.js's default of always rounding toward zero (effectively using `Math.floor()` for positive numbers) makes sense; for instance, if you're rounding to weeks, it may not be desirable to show "2 weeks" until you've actually hit 14 days, and instead display e.g. "1 week" if the duration is 13 days.