### PR TITLE
Custom number rendering feature

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -351,14 +351,14 @@
         ms: 1
       },
       numberRenderer: {
-        y: x => x,
-        mo: x => x,
-        w: x => x,
-        d: x => x,
-        h: x => x,
-        m: x => x,
-        s: x => x,
-        ms: x => x
+        y: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        mo: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        w: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        d: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        h: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        m: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        s: (decimalReplacedValue, originalValue) => decimalReplacedValue,
+        ms: (decimalReplacedValue, originalValue) => decimalReplacedValue
       }
     }, passedOptions)
   }
@@ -467,7 +467,9 @@
       throw new Error('Renderer ' + type + ' must be a function.')
     }
 
-    var countStr = numberRenderer(count).toString().replace('.', decimal)
+    var decimalReplacedValue = count.toString().replace('.', decimal)
+
+    var countStr = numberRenderer(decimalReplacedValue, count)
 
     var dictionaryValue = dictionary[type]
     var word

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -351,14 +351,14 @@
         ms: 1
       },
       numberRenderer: {
-        y: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        mo: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        w: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        d: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        h: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        m: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        s: (decimalReplacedValue, originalValue) => decimalReplacedValue,
-        ms: (decimalReplacedValue, originalValue) => decimalReplacedValue
+        y: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        mo: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        w: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        d: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        h: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        m: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        s: function (decimalReplacedValue, originalValue) { return decimalReplacedValue },
+        ms: function (decimalReplacedValue, originalValue) { return decimalReplacedValue }
       }
     }, passedOptions)
   }

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -349,6 +349,16 @@
         m: 60000,
         s: 1000,
         ms: 1
+      },
+      numberRender: {
+        y: x => x,
+        mo: x => x,
+        w: x => x,
+        d: x => x,
+        h: x => x,
+        m: x => x,
+        s: x => x,
+        ms: x => x
       }
     }, passedOptions)
   }
@@ -451,7 +461,13 @@
       decimal = options.decimal
     }
 
-    var countStr = count.toString().replace('.', decimal)
+    var numberRenderer = options.numberRender[type];
+
+    if (typeof numberRenderer !== "function"){
+      throw new Error('Renderer ' + type + ' must be a function.')
+    }
+
+    var countStr = numberRenderer(count).toString().replace('.', decimal)
 
     var dictionaryValue = dictionary[type]
     var word
@@ -550,4 +566,5 @@
   } else {
     this.humanizeDuration = humanizeDuration
   }
+
 })();  // eslint-disable-line semi

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -350,7 +350,7 @@
         s: 1000,
         ms: 1
       },
-      numberRender: {
+      numberRenderer: {
         y: x => x,
         mo: x => x,
         w: x => x,
@@ -461,9 +461,9 @@
       decimal = options.decimal
     }
 
-    var numberRenderer = options.numberRender[type];
+    var numberRenderer = options.numberRenderer[type]
 
-    if (typeof numberRenderer !== "function"){
+    if (typeof numberRenderer !== 'function') {
       throw new Error('Renderer ' + type + ' must be a function.')
     }
 
@@ -566,5 +566,4 @@
   } else {
     this.humanizeDuration = humanizeDuration
   }
-
 })();  // eslint-disable-line semi

--- a/test/error.js
+++ b/test/error.js
@@ -33,4 +33,20 @@ describe('error handling', function () {
     assert.throws(humanizing({ language: null }), Error)
     assert.doesNotThrow(humanizing({ language: 'es' }), Error)
   })
+
+  it('throws an error when passed a non-function numberRenderer', function () {
+    var h = humanizeDuration.humanizer({
+      numberRenderer: {
+        s: 'this is not a function'
+      }
+    })
+
+    function humanizing (options) {
+      return function () {
+        h(10000, options)
+      }
+    }
+
+    assert.throws(humanizing(1000), Error)
+  })
 })

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -80,6 +80,27 @@ describe('humanizer', function () {
     assert.equal(h(144000000), '1 week')
   })
 
+  it('can overwrite the numberRenderers in the initializer', function () {
+    var h = humanizer({
+      numberRenderer: {
+        y: x => x + 'y',
+        mo: x => x + 'mo',
+        w: x => x + 'w',
+        d: x => x + 'd',
+        h: x => x + 'h',
+        m: x => x + 'm',
+        s: x => x + 's',
+        ms: x => x + 'h'
+      }
+    })
+
+    assert.equal(h(1000), '1s second')
+    assert.equal(h(60000), '1m minute')
+    assert.equal(h(3600000), '1h hour')
+    assert.equal(h(86400000), '1d day')
+    assert.equal(h(31557600000), '1y year')
+  })
+
   it('can change the decimal', function () {
     var h = humanizer({
       units: ['s'],

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -113,6 +113,18 @@ describe('humanizer', function () {
     }), '1!!234 seconds')
   })
 
+  it('can use custom numberRenderer with possible conflicting decimal replacements', function () {
+    var h = humanizer({
+      units: ['s'],
+      decimal: 'what',
+      numberRenderer: {
+        s: (decimalReplacedValue, actualValue) => '...' + decimalReplacedValue + '...'
+      }
+    })
+
+    assert.equal(h(1234), '...1what234... seconds')
+  })
+
   it('can do simple rounding', function () {
     var h = humanizer({ round: true })
 

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -83,14 +83,14 @@ describe('humanizer', function () {
   it('can overwrite the numberRenderers in the initializer', function () {
     var h = humanizer({
       numberRenderer: {
-        y: x => x + 'y',
-        mo: x => x + 'mo',
-        w: x => x + 'w',
-        d: x => x + 'd',
-        h: x => x + 'h',
-        m: x => x + 'm',
-        s: x => x + 's',
-        ms: x => x + 'h'
+        y: function (x) { return x + 'y' },
+        mo: function (x) { return x + 'mo' },
+        w: function (x) { return x + 'w' },
+        d: function (x) { return x + 'd' },
+        h: function (x) { return x + 'h' },
+        m: function (x) { return x + 'm' },
+        s: function (x) { return x + 's' },
+        ms: function (x) { return x + 'ms' }
       }
     })
 
@@ -118,7 +118,7 @@ describe('humanizer', function () {
       units: ['s'],
       decimal: 'what',
       numberRenderer: {
-        s: (decimalReplacedValue, actualValue) => '...' + decimalReplacedValue + '...'
+        s: function (decimalReplacedValue, actualValue) { return '...' + decimalReplacedValue + '...' }
       }
     })
 


### PR DESCRIPTION
As discussed here:

https://github.com/EvanHahn/HumanizeDuration.js/issues/110

I added the ability to include custom number renderers on creation of the humanizer.

The only 'issue' that I couldn't cover was that it's an all or nothing approach. Every possible unit that is used will need a custom renderer. Missing a renderer will throw and error when trying to render.

The default renderers don't change any existing functionality.

There was potential conflicts with custom decimal markers, but I covered that case and wrote a unit test as well.