### PR TITLE
Fix second usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, Humanize Duration will humanize down to the second, and will return 
 
 ```js
 humanizeDuration(3000)      // '3 seconds'
-humanizeDuration(2015)      // '2.25 seconds'
+humanizeDuration(2250)      // '2.25 seconds'
 humanizeDuration(97320000)  // '1 day, 3 hours, 2 minutes'
 ```
 


### PR DESCRIPTION
Second usage example was wrong. Change input so the output will be as described.