### PR TITLE
"Short" option support

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -58,14 +58,14 @@
       decimal: ','
     },
     en: {
-      y: function (c) { return 'year' + (c === 1 ? '' : 's') },
-      mo: function (c) { return 'month' + (c === 1 ? '' : 's') },
-      w: function (c) { return 'week' + (c === 1 ? '' : 's') },
-      d: function (c) { return 'day' + (c === 1 ? '' : 's') },
-      h: function (c) { return 'hour' + (c === 1 ? '' : 's') },
-      m: function (c) { return 'minute' + (c === 1 ? '' : 's') },
-      s: function (c) { return 'second' + (c === 1 ? '' : 's') },
-      ms: function (c) { return 'millisecond' + (c === 1 ? '' : 's') },
+      y: function (c, s) { return s ? 'y' : 'year' + (c === 1 ? '' : 's') },
+      mo: function (c, s) { return s ? 'mo' : 'month' + (c === 1 ? '' : 's') },
+      w: function (c, s) { return s ? 'w' : 'week' + (c === 1 ? '' : 's') },
+      d: function (c, s) { return s ? 'd' : 'day' + (c === 1 ? '' : 's') },
+      h: function (c, s) { return s ? 'h' : 'hour' + (c === 1 ? '' : 's') },
+      m: function (c, s) { return s ? 'm' : 'minute' + (c === 1 ? '' : 's') },
+      s: function (c, s) { return s ? 's' : 'second' + (c === 1 ? '' : 's') },
+      ms: function (c, s) { return s ? 'ms' : 'millisecond' + (c === 1 ? '' : 's') },
       decimal: '.'
     },
     es: {
@@ -245,14 +245,14 @@
       decimal: ','
     },
     ru: {
-      y: function (c) { return ['лет', 'год', 'года'][getSlavicForm(c)] },
-      mo: function (c) { return ['месяцев', 'месяц', 'месяца'][getSlavicForm(c)] },
-      w: function (c) { return ['недель', 'неделя', 'недели'][getSlavicForm(c)] },
-      d: function (c) { return ['дней', 'день', 'дня'][getSlavicForm(c)] },
-      h: function (c) { return ['часов', 'час', 'часа'][getSlavicForm(c)] },
-      m: function (c) { return ['минут', 'минута', 'минуты'][getSlavicForm(c)] },
-      s: function (c) { return ['секунд', 'секунда', 'секунды'][getSlavicForm(c)] },
-      ms: function (c) { return ['миллисекунд', 'миллисекунда', 'миллисекунды'][getSlavicForm(c)] },
+      y: function (c, s) { return ['лет', 'год', 'года'][getSlavicForm(c)] },
+      mo: function (c, s) { return s ? 'мес' : ['месяцев', 'месяц', 'месяца'][getSlavicForm(c)] },
+      w: function (c, s) { return s ? 'нед' : ['недель', 'неделя', 'недели'][getSlavicForm(c)] },
+      d: function (c, s) { return s ? 'д.' : ['дней', 'день', 'дня'][getSlavicForm(c)] },
+      h: function (c, s) { return s ? 'ч' : ['часов', 'час', 'часа'][getSlavicForm(c)] },
+      m: function (c, s) { return s ? 'м' : ['минут', 'минута', 'минуты'][getSlavicForm(c)] },
+      s: function (c, s) { return s ? 'с' : ['секунд', 'секунда', 'секунды'][getSlavicForm(c)] },
+      ms: function (c, s) { return s ? 'мс' : ['миллисекунд', 'миллисекунда', 'миллисекунды'][getSlavicForm(c)] },
       decimal: ','
     },
     uk: {

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -340,6 +340,7 @@
       units: ['y', 'mo', 'w', 'd', 'h', 'm', 's'],
       languages: {},
       round: false,
+      short: false,
       unitMeasures: {
         y: 31557600000,
         mo: 2629800000,
@@ -456,7 +457,7 @@
     var dictionaryValue = dictionary[type]
     var word
     if (typeof dictionaryValue === 'function') {
-      word = dictionaryValue(count)
+      word = dictionaryValue(count, options.short)
     } else {
       word = dictionaryValue
     }

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -155,7 +155,7 @@ describe('humanizer', function () {
     assert.equal(humanizer().name, 'humanizer')
   })
 
-  it('can use short option', function () {
+  it('can use a short option', function () {
     var h = humanizer({ short: true })
     assert.equal(h(3692131200000), '116 y, 11 mo, 4 w, 1 d, 4 h, 30 m')
   })

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -155,6 +155,11 @@ describe('humanizer', function () {
     assert.equal(humanizer().name, 'humanizer')
   })
 
+  it('can use short option', function () {
+    var h = humanizer({ short: true })
+    assert.equal(h(3692131200000), '116 y, 11 mo, 4 w, 1 d, 4 h, 30 m')
+  })
+
   it('can add a new language', function () {
     var h = humanizer({ language: 'cool language' })
     h.languages['cool language'] = {


### PR DESCRIPTION
Hello!

I thought that adding a whole new short language is not the best solution for this problem, so I've decided to create a little option for supporting short words.

Usage:
`humanizeDuration(3692131200000, { short: true })`

I've added short words for English and Russian languages, so you can try it for yourself.

The default value for this option is **false**.
We're passing this parameter into the function, which returns shortly words if possible.

I think this method is much more flexible than adding a new language. Looking forward to your opinion.
