### PR TITLE
Allow a fallback for fault tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ humanizeDuration(3000, { language: 'es' })  // '3 segundos'
 humanizeDuration(5000, { language: 'ko' })  // '5 초'
 ```
 
+**fallback**
+Fallback language if the provided language cannot be found (accepts an [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) from one of the [supported languages](#supported-languages)).
+```js
+humanizeDuration(3000, { language: 'bad language', fallback: 'en' })  // '3 seconds'
+humanizeDuration(3000, { language: 'EN', fallback: 'en' })  // '3 seconds'
+```
+
+
 **delimiter**
 
 String to display between the previous unit and the next value.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ humanizeDuration(5000, { language: 'ko' })  // '5 초'
 ```
 
 **fallbacks**
+
 Fallback languages if the provided language cannot be found (accepts an [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) from one of the [supported languages](#supported-languages)). It works from left to right.
 ```js
 humanizeDuration(3000, { language: 'bad language', fallbacks: ['en'] })  // '3 seconds'

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ humanizeDuration(3000, { language: 'es' })  // '3 segundos'
 humanizeDuration(5000, { language: 'ko' })  // '5 초'
 ```
 
-**fallback**
-Fallback language if the provided language cannot be found (accepts an [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) from one of the [supported languages](#supported-languages)).
+**fallbacks**
+Fallback languages if the provided language cannot be found (accepts an [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) from one of the [supported languages](#supported-languages)). It works from left to right.
 ```js
-humanizeDuration(3000, { language: 'bad language', fallback: 'en' })  // '3 seconds'
-humanizeDuration(3000, { language: 'EN', fallback: 'en' })  // '3 seconds'
+humanizeDuration(3000, { language: 'bad language', fallbacks: ['en'] })  // '3 seconds'
+humanizeDuration(3000, { language: 'bad language', fallbacks: ['bad language', 'es'] })  // '3 segundos'
 ```
 
 

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -507,7 +507,7 @@
     // Has the nice sideffect of turning Number objects into primitives.
     ms = Math.abs(ms)
 
-    var dictionary = options.languages[options.language] || languages[options.language]
+    var dictionary = options.languages[options.language] || languages[options.language] || languages[options.fallback]
     if (!dictionary) {
       throw new Error('No language ' + dictionary + '.')
     }

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -499,6 +499,41 @@
   // The main function is just a wrapper around a default humanizer.
   var humanizeDuration = humanizer({})
 
+  // Compare a collection of languages against the specified type (language, or fallback)
+  function hasLanguage (collection, userLanguages) {
+    var value, i
+    if (!Array.isArray(collection)) {
+      return
+    }
+    // Allow an override, useful for switching between options.languages and languages
+    for (i = 0; i < collection.length; i++) {
+      value = collection[i]
+      // Check if languages has the array value
+      if (languages.hasOwnProperty(value)) {
+        return languages[value]
+      } else if (userLanguages.hasOwnProperty(value)) {
+        return userLanguages[value]
+      }
+    }
+  }
+  // Get the dictionary from the supplied language and possible fallback(s)
+  function getDictionary (options) {
+    var dictionary
+    if (options.languages.hasOwnProperty(options.language)) {
+      dictionary = options.languages[options.language]
+    } else if (languages.hasOwnProperty(options.language)) {
+      dictionary = languages[options.language]
+    }
+    // Attempt to get a fallback
+    if (!dictionary) {
+      dictionary = hasLanguage(options.fallbacks, options.languages)
+    }
+
+    if (!dictionary) {
+      throw new Error('No language ' + dictionary + '.')
+    }
+    return dictionary
+  }
   // doHumanization does the bulk of the work.
   function doHumanization (ms, options) {
     var i, len, piece
@@ -507,11 +542,7 @@
     // Has the nice sideffect of turning Number objects into primitives.
     ms = Math.abs(ms)
 
-    var dictionary = options.languages[options.language] || languages[options.language] || languages[options.fallback]
-    if (!dictionary) {
-      throw new Error('No language ' + dictionary + '.')
-    }
-
+    var dictionary = getDictionary(options)
     var pieces = []
 
     // Start at the top and keep removing units, bit by bit.

--- a/test/error.js
+++ b/test/error.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 describe('error handling', () => {
   it('throws an error when passed a bad language in the function', () => {
-    function humanizingWith(options) {
+    function humanizingWith (options) {
       return () => {
         humanizeDuration(10000, options)
       }
@@ -21,7 +21,7 @@ describe('error handling', () => {
       language: 'bad language'
     })
 
-    function humanizing(options) {
+    function humanizing (options) {
       return () => {
         humanizer(10000, options)
       }
@@ -36,7 +36,7 @@ describe('error handling', () => {
   })
 
   it('does not throw an error when passed a bad language in the function and a valid fallback specified', () => {
-    function humanizingWith(options) {
+    function humanizingWith (options) {
       return () => {
         humanizeDuration(10000, options)
       }

--- a/test/error.js
+++ b/test/error.js
@@ -36,14 +36,15 @@ describe('error handling', () => {
     assert.throws(humanizing({ language: ['es', 'en'] }), Error)
   })
 
-  it('does not throw an error when passed a bad language in the function and a valid fallback specified', () => {
+  it('should throw if fallbacks configuration is invalid', () => {
     function humanizingWith (options) {
       return () => {
         humanizeDuration(10000, options)
       }
     }
-
-    assert.doesNotThrow(humanizingWith({ language: 'BAD', fallbacks: ['en'] }), Error)
-    assert.doesNotThrow(humanizingWith({ language: 'BAD', fallbacks: ['BAD', 'en'] }), Error)
+    assert.throws(humanizingWith({ language: 'es', fallbacks: [] }), Error)
+    assert.throws(humanizingWith({ language: 'es', fallbacks: undefined }), Error)
+    assert.throws(humanizingWith({ language: 'es', fallbacks: null }), Error)
+    assert.throws(humanizingWith({ language: 'es', fallbacks: 'en' }), Error)
   })
 })

--- a/test/error.js
+++ b/test/error.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 
 describe('error handling', () => {
   it('throws an error when passed a bad language in the function', () => {
-    function humanizingWith (options) {
+    function humanizingWith(options) {
       return () => {
         humanizeDuration(10000, options)
       }
@@ -13,6 +13,7 @@ describe('error handling', () => {
     assert.throws(humanizingWith({ language: 'bad language' }), Error)
     assert.throws(humanizingWith({ language: '' }), Error)
     assert.throws(humanizingWith({ language: null }), Error)
+    assert.throws(humanizingWith({ language: 'bad language', fallback: null }), Error)
   })
 
   it('throws an error when passed a bad language in a humanizer', () => {
@@ -20,7 +21,7 @@ describe('error handling', () => {
       language: 'bad language'
     })
 
-    function humanizing (options) {
+    function humanizing(options) {
       return () => {
         humanizer(10000, options)
       }
@@ -32,5 +33,15 @@ describe('error handling', () => {
     assert.throws(humanizing({ language: '' }), Error)
     assert.throws(humanizing({ language: null }), Error)
     assert.doesNotThrow(humanizing({ language: 'es' }), Error)
+  })
+
+  it('does not throw an error when passed a bad language in the function and a valid fallback specified', () => {
+    function humanizingWith(options) {
+      return () => {
+        humanizeDuration(10000, options)
+      }
+    }
+
+    assert.doesNotThrow(humanizingWith({ language: 'EN', fallback: 'en' }), Error)
   })
 })

--- a/test/error.js
+++ b/test/error.js
@@ -33,6 +33,7 @@ describe('error handling', () => {
     assert.throws(humanizing({ language: '' }), Error)
     assert.throws(humanizing({ language: null }), Error)
     assert.doesNotThrow(humanizing({ language: 'es' }), Error)
+    assert.throws(humanizing({ language: ['es', 'en'] }), Error)
   })
 
   it('does not throw an error when passed a bad language in the function and a valid fallback specified', () => {
@@ -42,6 +43,7 @@ describe('error handling', () => {
       }
     }
 
-    assert.doesNotThrow(humanizingWith({ language: 'EN', fallback: 'en' }), Error)
+    assert.doesNotThrow(humanizingWith({ language: 'BAD', fallbacks: ['en'] }), Error)
+    assert.doesNotThrow(humanizingWith({ language: 'BAD', fallbacks: ['BAD', 'en'] }), Error)
   })
 })

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -225,4 +225,20 @@ describe('humanizer', () => {
     assert.equal(h(15600000), '4 h, 20 m')
     assert.equal(h(1000, { language: 'es' }), '1 segundo')
   })
+
+  it('accepts fallback languages', () => {
+    const h = humanizer()
+
+    assert.strictEqual(h(10000, { language: 'es', fallbacks: ['en'] }), '10 segundos')
+    assert.strictEqual(h(10000, { language: 'BAD', fallbacks: ['BAD', 'es'] }), '10 segundos')
+  })
+
+  it('should not resolve a language with an invalid configuration', function () {
+    const h = humanizer()
+
+    assert.strictEqual(h(10000, { language: 'es', fallbacks: 'en' }), '10 segundos')
+    // Default language is en
+    assert.strictEqual(h(10000, { fallbacks: ['es'] }), '10 seconds')
+    assert.strictEqual(h(10000, { fallbacks: [] }), '10 seconds')
+  })
 })

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -231,14 +231,6 @@ describe('humanizer', () => {
 
     assert.strictEqual(h(10000, { language: 'es', fallbacks: ['en'] }), '10 segundos')
     assert.strictEqual(h(10000, { language: 'BAD', fallbacks: ['BAD', 'es'] }), '10 segundos')
-  })
-
-  it('should not resolve a language with an invalid configuration', function () {
-    const h = humanizer()
-
-    assert.strictEqual(h(10000, { language: 'es', fallbacks: 'en' }), '10 segundos')
-    // Default language is en
-    assert.strictEqual(h(10000, { fallbacks: ['es'] }), '10 seconds')
-    assert.strictEqual(h(10000, { fallbacks: [] }), '10 seconds')
+    assert.strictEqual(h(10000, { language: 'BAD', fallbacks: ['es', 'fr'] }), '10 segundos')
   })
 })


### PR DESCRIPTION
It's useful to provide a fallback language instead of throwing. Before, the other alternative was wrapping the humanizeDuration in a try catch and trying again with a known locale. This pull request add support for a fallback language in case of failure. If the fallback language cannot be found, then we proceed to throw as normal. 


Tests added and docs updated.

```js
humanizeDuration(3000, { language: 'bad language', fallback: 'en' })  // '3 seconds'
humanizeDuration(3000, { language: 'EN', fallback: 'en' })  // '3 seconds'
```