### PR TITLE
fix: display decimals on largest unit #171

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -711,6 +711,8 @@
 
   function toFixed (num, fixed) {
     var re = new RegExp('^-?\\d+(?:.\\d{0,' + (fixed || -1) + '})?')
+    var matches = num.toString().match(re)
+    if (!matches) return num // can be undefined when num is Number.POSITIVE_INFINITY
     return parseFloat(num.toString().match(re)[0], 10)
   }
 

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -106,6 +106,16 @@ describe('humanizer', () => {
     assert.strictEqual(h(121500), '2 minutes, 2 seconds')
   })
 
+  it('can handle rounding with the "largest" option without truncating the largest units', () => {
+    const h = humanizer({ round: true })
+    assert.strictEqual(h(739160000, { largest: 2 }), '1 week, 2 days')
+    assert.strictEqual(h(739160000, { largest: 2 }), '1 week, 2 days')
+    assert.strictEqual(h(7199000, { largest: 2 }), '2 hours')
+    assert.strictEqual(h(7199000, { largest: 3 }), '1 hour, 59 minutes, 59 seconds')
+    assert.strictEqual(h(7201000, { largest: 2 }), '2 hours')
+    assert.strictEqual(h(7201000, { largest: 3 }), '2 hours, 1 second')
+  })
+
   it('can do rounding with the "units" option', () => {
     const h = humanizer({ round: true })
 
@@ -144,6 +154,36 @@ describe('humanizer', () => {
     assert.strictEqual(h(7999), '7.99 seconds')
     h.maxDecimalPoints = 3
     assert.strictEqual(h(7999), '7.999 seconds')
+  })
+
+  it('can return floating point result with the "maxDecimalPoint" and the "largest" options', () => {
+    const h = humanizer({ round: false })
+
+    h.maxDecimalPoints = 1
+    assert.strictEqual(h(8123.456789, { largest: 1 }), '8.1 seconds')
+    assert.strictEqual(h(80000, { largest: 1 }), '1.3 minutes')
+    assert.strictEqual(h(450000, { largest: 1 }), '7.5 minutes')
+    assert.strictEqual(h(540360012, { largest: 2 }), '6 days, 6.1 hours')
+
+    h.maxDecimalPoints = 2
+    assert.strictEqual(h(8123.456789, { largest: 1 }), '8.12 seconds')
+    assert.strictEqual(h(80000, { largest: 1 }), '1.33 minutes')
+    assert.strictEqual(h(450000, { largest: 1 }), '7.5 minutes')
+    assert.strictEqual(h(540360012, { largest: 2 }), '6 days, 6.1 hours')
+
+    assert.strictEqual(h(3692131200001, { largest: 6 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30 minutes')
+
+    h.maxDecimalPoints = 7
+    assert.strictEqual(h(3692131200001, { largest: 6 }), '116 years, 11 months, 4 weeks, 1 day, 4 hours, 30.0000166 minutes')
+  })
+
+  it('can return floating point result with the "maxDecimalPoint", "largest" and "units" options', () => {
+    const h = humanizer({ round: false, units: ['h', 'm'] })
+
+    h.maxDecimalPoints = 1
+    assert.strictEqual(h(5400000, { largest: 1 }), '1.5 hours')
+    assert.strictEqual(h(5400001, { largest: 1 }), '1.5 hours')
+    assert.strictEqual(h(5400001, { largest: 2 }), '1 hour, 30 minutes')
   })
 
   it('can ask for the largest units', function () {

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -156,6 +156,15 @@ describe('humanizer', () => {
     assert.strictEqual(h(7999), '7.999 seconds')
   })
 
+  it('does not throw when passing Infinity', () => {
+    var h = humanizer({ maxDecimalPoints: 2 })
+    assert.strictEqual(h(Number.POSITIVE_INFINITY), 'Infinity years')
+    assert.strictEqual(h(Number.NEGATIVE_INFINITY), 'Infinity years')
+
+    h.units = ['h', 'm']
+    assert.strictEqual(h(Number.POSITIVE_INFINITY), 'Infinity hours')
+  })
+
   it('can return floating point result with the "maxDecimalPoint" and the "largest" options', () => {
     const h = humanizer({ round: false })
 

--- a/test/humanizer.js
+++ b/test/humanizer.js
@@ -201,9 +201,8 @@ describe('humanizer', () => {
     assert.strictEqual(h(0), '0 seconds')
     assert.strictEqual(h(1000), '1 second')
     assert.strictEqual(h(2000), '2 seconds')
-    assert.strictEqual(h(540360012), '6 days, 6 hours')
-    assert.strictEqual(h(540360012), '6 days, 6 hours')
-    assert.strictEqual(h(540360012, { largest: 3 }), '6 days, 6 hours, 6 minutes')
+    assert.strictEqual(h(540360012), '6 days, 6.100003333333333 hours')
+    assert.strictEqual(h(540360012, { largest: 3 }), '6 days, 6 hours, 6.0002 minutes')
     assert.strictEqual(h(540360012, { largest: 100 }), '6 days, 6 hours, 6 minutes, 0.012 seconds')
   })
 


### PR DESCRIPTION
Fixes https://github.com/EvanHahn/HumanizeDuration.js/issues/150

As explained in the issue, using the library with `largest` set (with or without units specified), results in leaving the decimal part for units larger than second.

- This fixes this behaviour and adds unit tests
- I changed the way rounding was working since it leads to [inaccurate results](https://stackoverflow.com/questions/4187146/truncate-number-to-two-decimal-places-without-rounding)
- Added some tests regarding: https://github.com/EvanHahn/HumanizeDuration.js/issues/141 since it was linked to the issue above. I don't see any problems there though.


Now, some tests are breaking, specifically:

    const h = humanizer({ largest: 2 })
    assert.strictEqual(h(540360012), '6 days, 6 hours')
    assert.strictEqual(h(540360012, { largest: 3 }), '6 days, 6 hours, 6 minutes')

I haven't touched those to avoid hiding this. I think it's reasonable to have those tests failed if `round` or `maxDecimalPoints` is not provided, the only issue is that it's going to be a "breaking" change in those cases.

You can leave it as is (and fix the test ofc), and publish a major version, or only apply the remainder if `maxDecimalPoints` has been provided, what do you think ?
