### PR TITLE
Update humanize-duration.js

### DIFF
--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -35,7 +35,7 @@
     decimal: ","
   };
 
-  var ARABIC_DIGITS = ["۰", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"];
+  var ARABIC_DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
   var LANGUAGES = {
     af: {


### PR DESCRIPTION
~~["۰", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"]; this is not arabic numbers ,The numbers used worldwide are Arabic numerals.
0123456789~~
1234567890 and ١٢٣٤٥٦٧٨٩٠ => Also Arabic
But ١٢٣٤٥٦٧٨٩٠ makes texts Unbalanced with other texts in most interfaces
مرحبا Test ١٢٣٤٥٦٧٨٩٠
مرحبا 1234567890 Test
Which makes style bad

1234567890 => Muhammad bin Musa Al-Khwarizmi  'Mathematician 
١٢٣٤٥٦٧٨٩٠ => Ibrahim Al-Fazari'Astronomer 