### PR TITLE
docs: Add link to new fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,3 +460,4 @@ Licensed under the permissive [Unlicense](https://unlicense.org/). Enjoy!
 - [HumanizeDuration.ts](https://github.com/Nightapes/HumanizeDuration.ts), a TypeScript version of this module
 - [aurelia-time](https://github.com/shahabganji/aurelia-time)
 - [Fork that adds a `timeAdverb` option](https://github.com/cmldk/HumanizeDuration.js)
+- [Fork that provides the duration in an abbreviated format](https://github.com/rasa/HumanizeDuration.js), ex: `1d 2h 3m 4s`


### PR DESCRIPTION
I chose to dual-license with the MIT license,
due to the possible issues with the Unlicense
license in some countries. See
https://softwareengineering.stackexchange.com/a/147120 for details.

As the first commit was in 2013, in
9c3f64a#diff-d0ed4cc3fb70489fe51c7e0ac180cba2a7472124f9f9e9ae67b01a37fbd580b7 and it included a copyright, I am including a
copyright statement in the MIT license.

I hope that's OK.