### PR TITLE
fix: use singular Lithuanian form for counts like 101 and 201

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- fix: Lithuanian now uses the singular form for counts such as 101 and 201 (for example "101 diena" instead of "101 dienų")
+
 # 3.33.2 / 2025-12-07
 
 - fix: Romanian now correctly uses "de" before nouns for numbers >= 20 such as "20 de minute" instead of "20 minute" (see [#235](https://github.com/EvanHahn/HumanizeDuration.js/pull/235))

--- a/humanize-duration.js
+++ b/humanize-duration.js
@@ -1218,7 +1218,7 @@
    * @returns {0 | 1 | 2}
    */
   function getLithuanianForm(c) {
-    if (c === 1 || (c % 10 === 1 && c % 100 > 20)) {
+    if (c % 10 === 1 && c % 100 !== 11) {
       return 0;
     }
     if (

--- a/test/definitions/lt.tsv
+++ b/test/definitions/lt.tsv
@@ -3,6 +3,8 @@
 2	2 milisekundės
 5	5 milisekundės
 12	12 milisekundžių
+101	101 milisekundė
+211	211 milisekundžių
 420	420 milisekundžių
 500	500 milisekundžių
 1000	1 sekundė


### PR DESCRIPTION
The Lithuanian plural helper picks the wrong form for counts whose last two digits are "01" (101, 201, 301, and so on). It returns the genitive plural instead of the singular, so a 101 ms duration renders as "101 milisekundžių" instead of "101 milisekundė".

`getLithuanianForm` detected the singular ("one") form with:

```js
c === 1 || (c % 10 === 1 && c % 100 > 20)
```

The `c % 100 > 20` guard is there to exclude 11 (where Lithuanian uses the plural), but it also excludes `c % 100 === 1` (101, 201, ...), which should be singular. The Latvian helper right below it already uses the correct idiom:

```js
return c % 10 === 1 && c % 100 !== 11;
```

That also matches the CLDR Lithuanian rule, where `one` is `i % 10 = 1 and i % 100 != 11..19`; for the integer counts handled here that reduces to `i % 10 === 1 && i % 100 !== 11`. So 1, 21, 31, ..., 101, 121 are singular and 11, 111, 211 stay plural.

This reuses that idiom for Lithuanian. The counts that were already correct (1, 21 through 91, and 11..19) are unchanged; only 101, 201, ..., 901 move from the plural to the singular form.

Also added two rows to `test/definitions/lt.tsv` (101 -> singular, 211 -> still plural) and a `HISTORY.md` entry.
